### PR TITLE
Drop testing on 3.5

### DIFF
--- a/suitcase-{{ cookiecutter.subproject_name }}/.travis.yml
+++ b/suitcase-{{ cookiecutter.subproject_name }}/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 3.5
   - 3.6
 cache:
   directories:


### PR DESCRIPTION
At the databroker hackathon, we discussed supporting 3.6+ only, in particular
because suitcase packages are likely to make good use of f-strings.