### PR TITLE
Add CI that will verify cookiecutter creates a working package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+suitcase-example/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: python
+python:
+  - 3.6
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  - set -e
+  # Generate an example suitcase pacakge by simulating user input to cookiecutter.
+  - ./run_cookiecutter_example.py
+  # Install the new package.
+  - pip install -e ./suitcase-example 
+  # Check that it is importable.
+  - python -c "from suitcase.example import Serializer, export"
+  # Now install suitcase-example's development dependencies.
+  - pip install -r suitcase-example/requirements-dev.txt 
+  # Run the example parametrized test.
+  - pytest suitcase-example/
+  # Run flake8.
+  - flake8 --max-line-length=115 suitcase-example/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# These are the requirements for testing the cookiecutter itself.
+# See a separate requirements.txt file inside the cookiecutter.
+cookiecutter
+pexpect

--- a/run_cookiecutter_example.py
+++ b/run_cookiecutter_example.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+import pexpect
+
+p = pexpect.spawn('cookiecutter .')
+
+p.expect('subproject_name.*')
+p.sendline('example')
+
+p.expect('subpackage_name.*')
+p.sendline('example')
+
+# Runs until the cookiecutter is done; then exits.
+p.interact()

--- a/suitcase-{{ cookiecutter.subproject_name }}/requirements.txt
+++ b/suitcase-{{ cookiecutter.subproject_name }}/requirements.txt
@@ -1,2 +1,3 @@
 # List required packages in this file, one per line.
+event-model >=1.8.0rc2
 suitcase.utils


### PR DESCRIPTION
Following the pattern from scientific-python-cookiecutter, Travis will
now run a script that simulates user input to cookiecutter's prompts and
creates a new suitcase package, ``suitcase-example``. It verifies that the
package works out of the box: it should be importable, the example parametrized
test should pass (even though the ``Serializer`` sketch doesn't actually *do*
anything), and ``flake8`` should be satisfied.

This revealed one missing dependency in the cookiecutter, added in a separate
commit in this PR.