### PR TITLE
BLD: Include requirements.txt in MANIFEST.in.

### DIFF
--- a/suitcase-{{ cookiecutter.subproject_name }}/MANIFEST.in
+++ b/suitcase-{{ cookiecutter.subproject_name }}/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.md
+include requirements.txt
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
I discovered this after pushing v0.1.0 of all the suitcases to PyPI and then
attempting to build conda packages with `conda skelethon pypi ...`, which
errored out.

I pushed a fix to master for all the published suitcase and tagged v0.1.1 for
each.