### PR TITLE
DOC/BLD: add the markdown content type to setup.py

### DIFF
--- a/suitcase-{{ cookiecutter.subproject_name }}/requirements-dev.txt
+++ b/suitcase-{{ cookiecutter.subproject_name }}/requirements-dev.txt
@@ -4,7 +4,7 @@ codecov
 coverage
 flake8
 # TEMPORARY UNTIL https://github.com/NSLS-II/ophyd/pull/682 IS RELEASED
-git+git://github.com/awalter-bnl/ophyd@add-configure
+git+git://github.com/NSLS-II/ophyd@ophyd-for-suitcase-utils
 pytest >=3.9
 sphinx
 suitcase-utils[test_fixtures] >=0.1.0rc2

--- a/suitcase-{{ cookiecutter.subproject_name }}/setup.py
+++ b/suitcase-{{ cookiecutter.subproject_name }}/setup.py
@@ -38,6 +38,7 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     long_description=readme,
+    long_description_content_type='text/markdown',
     packages=['suitcase.{{ cookiecutter.subpackage_name }}',
               'suitcase.{{ cookiecutter.subpackage_name }}.tests'],
     entry_points={


### PR DESCRIPTION
See the motivation here: https://github.com/NSLS-II/event-model/pull/64.

Probably should be propagated to all derived suitcases. Any assistance with this is appreciated.